### PR TITLE
Aanpassingen voor schooljaar 2023/24

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -35,8 +35,7 @@
   <table>
     <caption>Eindniveau met bijbehorende gedragscriteria en -indicatoren</caption>
     <tr>
-      <th colspan="5">De student ontwerpt en ontwikkelt zelfstandig complexe gebruiksvriendelijke, interactieve toepassingen voor het web. De student beheerst de principes van het web, kan API’s en databases gebruiken, kan frameworks, templates en build tools inzetten, en werkt volgens gangbare ontwikkelmethoden.
-      </th>
+      <th colspan="5">De student ontwerpt en ontwikkelt zelfstandig complexe gebruiksvriendelijke interactieve toepassingen voor het web. De student beheerst de principes van het web, kan API’s en databases gebruiken, kan tools en frameworks inzetten, en werken volgens gangbare ontwikkelmethoden.</th>
     </tr>
     <tr>
       <th class="methodisch-handelen">1. Methodisch handelen</th>
@@ -49,21 +48,21 @@
       <td class="methodisch-handelen" id="4.1.1">4.1.1 Richt projecten efficiënt en effectief in volgens de development-lifecycle en houdt rekening met de beschikbare tijd.</td>
       <td class="samenwerken" id="4.2.1">4.2.1 Werkt in teams, reflecteert op efficiëntie en effectiviteit en stuurt bij waar nodig.</td>
       <td class="communiceren" id="4.3.1">4.3.1 Betrekt gesprekspartners, luistert, vat samen, verifieert en vraagt door tot een boodschap helder is.</td>
-      <td class="probleemoplossend-vermogen" id="4.4.1">4.4.1 Analyseert een vraag, signaleert knelpunten, kiest onderbouwd richting en houdt rekening met directe gevolgen van keuzes.</td>
+      <td class="probleemoplossend-vermogen" id="4.4.1">4.4.1 Analyseert een vraag, signaleert knelpunten, kiest onderbouwd oplossingsrichting en valideert resultaten.</td>
       <td class="lerend-vermogen" id="4.5.1">4.5.1 Blijft op de hoogte van internationale ontwikkelingen in het vakgebied, omarmt verandering en maakt zelfstandig keuzes over eigen ontwikkeling.</td>
     </tr>
     <tr>
-      <td class="methodisch-handelen" id="4.1.2">4.1.2 Combineert principes, conventies en best-practices op het gebied van frontend, interface design en vormgeving en zet deze flexibel en onderbouwd in.</td>
+      <td class="methodisch-handelen" id="4.1.2">4.1.2 Combineert principes, standaarden en best-practices op het gebied van frontend design en development en zet deze flexibel en onderbouwd in om een passende oplossing voor een opdrachtgever te realiseren.</td>
       <td class="samenwerken" id="4.2.2">4.2.2 Draagt verantwoording voor eigen en teamresultaten en stuurt verwachtingen van belanghebbenden.</td>
       <td class="communiceren" id="4.3.2">4.3.2 Presenteert en onderbouwt op overtuigende wijze ontwerpkeuzes, eigen ideeën en producten passend bij het publiek.</td>
-      <td class="probleemoplossend-vermogen" id="4.4.2">4.4.2 Combineert onderbouwd frontend principes, conventies en best-practices op inventieve wijze om een passende oplossing voor een opdrachtgever te realiseren.</td>
+      <td class="probleemoplossend-vermogen" id="4.4.2">4.4.2 Schetst om gedachten en processen bespreekbaar te maken, abstracte begrippen over te brengen en de oplossingsrichting inzichtelijk te maken.</td>
       <td class="lerend-vermogen" id="4.5.2">4.5.2 Maakt zelfstandig nieuwe materie eigen, gebruikt dit bij beroepstaken, deelt ervaring met belanghebbenden en leert van anderen.</td>
     </tr>
     <tr>
       <td class="methodisch-handelen" id="4.1.3">4.1.3 Bewaakt de belangen van de eindgebruiker bij het realiseren van een oplossing voor een opdrachtgever.</td>
       <td class="samenwerken" id="4.2.3">4.2.3 Houdt rekening met diversiteit binnen teams en handelt respectvol naar anderen.</td>
       <td class="communiceren" id="4.3.3">4.3.3 Documenteert op professionele wijze en bespreekt voortgang met belanghebbenden.</td>
-      <td class="probleemoplossend-vermogen" id="4.4.3">4.4.3 Schetst om gedachten en processen bespreekbaar te maken, abstracte begrippen over te brengen en de oplossingsrichting inzichtelijk te maken.</td>
+      <td class="probleemoplossend-vermogen" id="4.4.3">4.4.3 Bedenkt en implementeert complexe frontend code en gebruikt daarbij de fundamentele principes van het web, API's, databases, tools en frameworks.</td>
       <td class="lerend-vermogen" id="4.5.3">4.5.3 Kent eigen capaciteiten en beperkingen, waardeert het vermogen van anderen, maakt dit bespreekbaar en schakelt zelfstandig hulp in waar nodig.</td>
     </tr>
   </table>
@@ -71,9 +70,9 @@
   
   <h2>Semester 3 - Workflow, Tooling & Frameworks</h2>
   <table>
-    <caption>Nveaubeschrijving semester 3 met bijbehorende gedragscriteria en -indicatoren</caption>
+    <caption>Niveaubeschrijving semester 3 met bijbehorende gedragscriteria en -indicatoren</caption>
     <tr>
-      <th colspan="5">De student werkt volgens gangbare ontwikkelmethoden, en gebruikt frameworks, templates en build tools voor het ontwerpen en ontwikkelen van complexe gebruiksvriendelijke interactieve toepassingen voor het web.</th>
+      <th colspan="5">De student werkt volgens gangbare ontwikkelmethoden, en gebruikt tools en frameworks voor het ontwerpen en ontwikkelen van complexe gebruiksvriendelijke interactieve toepassingen voor het web.</th>
     </tr>
     <tr>
       <th class="methodisch-handelen">1. Methodisch handelen</th>
@@ -90,17 +89,17 @@
       <td class="lerend-vermogen" id="3.5.1">3.5.1 Volgt aangeboden internationale ontwikkelingen in het vakgebied en maakt onder begeleiding keuzes over eigen ontwikkeling.</td>
     </tr>
     <tr>
-      <td class="methodisch-handelen" id="3.1.2">3.1.2 Combineert onderbouwd principes, conventies en best-practices op het gebied van frontend, interface design en vormgeving.</td>
+      <td class="methodisch-handelen" id="3.1.2">3.1.2 Combineert onderbouwd principes, conventies en best-practices op het gebied van frontend design en development.</td>
       <td class="samenwerken" id="3.2.2">3.2.2 Draagt verantwoording voor eigen resultaten, benoemt teamresultaten en informeert belanghebbenden over de voortgang.</td>
       <td class="communiceren" id="3.3.2">3.3.2 Kan ontwerpkeuzes, eigen ideeën en producten overtuigend overbrengen aan belanghebbenden.</td>
-      <td class="probleemoplossend-vermogen" id="3.4.2">3.4.2 Selecteert de juiste principes, conventies en best-practices op het gebied van frontend, interface design en vormgeving om een passende oplossing voor een opdrachtgever te realiseren.</td>
+      <td class="probleemoplossend-vermogen" id="3.4.2">3.4.2 Schetst om gedachten en processen te verkennen, abstracte begrippen over te brengen en de oplossingsrichting inzichtelijk te maken.</td>
       <td class="lerend-vermogen" id="3.5.2">3.5.2 Maakt aangeboden en zelf gevonden materie eigen, gebruikt dit bij leertaken, deelt ervaring binnen de squad en leert van anderen.</td>
     </tr>
     <tr>
       <td class="methodisch-handelen" id="3.1.3">3.1.3 Weegt belangen van de eindgebruiker en de eisen en wensen van een opdrachtgever af bij het realiseren van een oplossing voor een opdrachtgever.</td>
       <td class="samenwerken" id="3.2.3">3.2.3 Kan omgaan met diversiteit binnen teams en handelt respectvol naar anderen.</td>
       <td class="communiceren" id="3.3.3">3.3.3 Documenteert op professionele wijze en bespreekt voortgang binnen het team.</td>
-      <td class="probleemoplossend-vermogen" id="3.4.3">3.4.3 Schetst om gedachten en processen te verkennen, abstracte begrippen over te brengen en de oplossingsrichting inzichtelijk te maken.</td>
+      <td class="probleemoplossend-vermogen" id="3.4.3">3.4.3 Bedenkt en implementeert complexe frontend code en gebruikt daarbij tools en frameworks.</td>
       <td class="lerend-vermogen" id="3.5.3">3.5.3 Kent eigen capaciteiten en beperkingen, waardeert het vermogen van anderen en maakt dit bespreekbaar.</td>
     </tr>
   </table>
@@ -108,7 +107,7 @@
   
   <h2>Semester 2 - Data-Driven Web</h2>
   <table>
-    <caption>Nveaubeschrijving semester 2 met bijbehorende gedragscriteria en -indicatoren</caption>
+    <caption>Niveaubeschrijving semester 2 met bijbehorende gedragscriteria en -indicatoren</caption>
     <tr>
       <th colspan="5">De student gebruikt API's en databases voor het ontwerpen en ontwikkelen van gebruiksvriendelijke interactieve toepassingen voor het web.</th>
     </tr>
@@ -127,17 +126,17 @@
       <td class="lerend-vermogen" id="2.5.1">2.5.1 Volgt aangeboden internationale ontwikkelingen in het vakgebied.</td>
     </tr>
     <tr>
-      <td class="methodisch-handelen" id="2.1.2">2.1.2 Combineert aangeboden principes en conventies op het gebied van frontend, interface design en vormgeving.</td>
+      <td class="methodisch-handelen" id="2.1.2">2.1.2 Combineert aangeboden principes en conventies op het gebied van frontend design en development.</td>
       <td class="samenwerken" id="2.2.2">2.2.2 Draagt verantwoording voor eigen resultaten, verwerkt ontvangen feedback en wijst teamleden op hun verantwoording.</td>
       <td class="communiceren" id="2.3.2">2.3.2 Kan ontwerpkeuzes, eigen ideeën en producten begrijpelijk overbrengen aan belanghebbenden.</td>
-      <td class="probleemoplossend-vermogen" id="2.4.2">2.4.2 Combineert aangeboden principes en conventies op het gebied van frontend, interface design en vormgeving om een passende oplossing voor een opdrachtgever te realiseren.</td>
+      <td class="probleemoplossend-vermogen" id="2.4.2">2.4.2 Schetst om gedachten en processen te verkennen en abstracte begrippen over te brengen.</td>
       <td class="lerend-vermogen" id="2.5.2">2.5.2 Maakt aangeboden en zelf gevonden materie eigen en gebruikt dit bij leertaken, deelt ervaring binnen de squad.</td>
     </tr>
     <tr>
       <td class="methodisch-handelen" id="2.1.3">2.1.3 Houdt in beginnende mate rekening met de belangen van de eindgebruiker bij het realiseren van een oplossing voor een opdrachtgever.</td>
       <td class="samenwerken" id="2.2.3">2.2.3 Identificeert diversiteit binnen teams en handelt respectvol naar anderen.</td>
       <td class="communiceren" id="2.3.3">2.3.3 Documenteert op professionele wijze en houdt voortgang bij.</td>
-      <td class="probleemoplossend-vermogen" id="2.4.3">2.4.3 Schetst om gedachten en processen te verkennen en abstracte begrippen over te brengen.</td>
+      <td class="probleemoplossend-vermogen" id="2.4.3">2.4.3 Bedenkt en implementeert complexere frontend code en gebruikt daarbij API's en databases.</td>
       <td class="lerend-vermogen" id="2.5.3">2.5.3 Kent eigen capaciteiten en beperkingen, vergelijkt dit met het vermogen van anderen en maakt dit bespreekbaar.</td>
     </tr>
   </table>
@@ -145,7 +144,7 @@
   
   <h2>Semester 1 - Static Web</h2>
   <table>
-    <caption>Nveaubeschrijving semester 1 met bijbehorende gedragscriteria en -indicatoren</caption>
+    <caption>Niveaubeschrijving semester 1 met bijbehorende gedragscriteria en -indicatoren</caption>
     <tr>
       <th colspan="5">De student gebruikt fundamentele principes van het web voor het ontwerpen en ontwikkelen van eenvoudige gebruiksvriendelijke interactieve toepassingen voor het web.</th>
     </tr>
@@ -164,17 +163,17 @@
       <td class="lerend-vermogen" id="1.5.1">1.5.1 Benoemt behandelde internationale ontwikkelingen in het vakgebied.</td>
     </tr>
     <tr>
-      <td class="methodisch-handelen" id="1.1.2">1.1.2 Past aangeboden principes en conventies op het gebied van frontend, interface design en vormgeving toe.</td>
+      <td class="methodisch-handelen" id="1.1.2">1.1.2 Past aangeboden principes en conventies op het gebied van frontend design en development.</td>
       <td class="samenwerken" id="1.2.2">1.2.2 Draagt verantwoording voor eigen resultaten en verwerkt ontvangen feedback.</td>
       <td class="communiceren" id="1.3.2">1.3.2 Kan binnen de squad ontwerpkeuzes, eigen ideeën en producten begrijpelijk verwoorden.</td>
-      <td class="probleemoplossend-vermogen" id="1.4.2">1.4.2 Gebruikt aangeboden principes en conventies op het gebied van frontend, interface design en vormgeving om een passende oplossing voor een opdrachtgever te realiseren.</td>
+      <td class="probleemoplossend-vermogen" id="1.4.2">1.4.2 Schetst om gedachten en processen te verkennen.</td>
       <td class="lerend-vermogen" id="1.5.2">1.5.2 Maakt aangeboden materie eigen en gebruikt dit bij leertaken.</td>
     </tr>
     <tr>
-      <td class="methodisch-handelen" id="1.1.3">1.1.3 Realiseert een oplossing voor een opdrachtgever.</td>
+      <td class="methodisch-handelen" id="1.1.3">1.1.3 Realiseert een oplossing voor een opdrachtgever en de eindgebruikers.</td>
       <td class="samenwerken" id="1.2.3">1.2.3 Handelt respectvol naar anderen.</td>
       <td class="communiceren" id="1.3.3">1.3.3 Documenteert volgens aangeboden richtlijnen en houdt voortgang bij.</td>
-      <td class="probleemoplossend-vermogen" id="1.4.3">1.4.3 Schetst om gedachten en processen te verkennen.</td>
+      <td class="probleemoplossend-vermogen" id="1.4.3">1.4.3 Bedenkt en implementeert eenvoudige frontend code en gebruikt daarbij de fundamentele principes van het web.</td>
       <td class="lerend-vermogen" id="1.5.3">1.5.3 Toont beginnend inzicht in eigen capaciteiten en beperkingen en kan deze benoemen.</td>
     </tr>
   </table>


### PR DESCRIPTION
# Aanpassingen

## Leerresultaten S3 en S4

Inhoudelijk veranderd er niets, tekstueel is de zin "kan frameworks, templates en build tools inzetten" aangepast naar "kan tools en frameworks inzetten".

## *.1.2

De opsomming "frontend, interface design en vormgeving" is aangepast naar "frontend design en development". Reden voor aanpassing is dat de eerste variant nog heel erg vanuit de disciplines van CMD geformuleerd is terwijl we onze eigen opleidingsnaam hebben die onze disciplines beslaat. De nieuwe variant omarmt onze opleidingsnaam. Daarnaast is de gerichtheid op de opdrachtgever toegevoegd omdat de dubbeling met *.4.2 opgeheven wordt (zie verderop)

## 1.1.3

Ook op het eerste niveau is de eindgebruiker toegevoegd.

## 4.4.1

Het valideren van resultaten is toegevoegd op het hoogste niveau. Andere niveau's blijven onveranderd.

## *.4.2

Schetsen is van plaats veranderd om het proces van de DLC beter te reflecteren. Inhoudelijk is er niets veranderd.

## *.4.3

De oude variant (op plaats *.4.2) had een dubbeling met indicator *.1.2 met een toespitsing op de opdrachtgever. Deze toespitsing is toegevoegd bij *.1.2 en deze indicator wordt gericht op code, iets wat ontbreekt in de huidige versie. Net als bij de andere indicatoren wordt een oplopende complexiteitsschaal gehanteerd.
